### PR TITLE
Add external data checker config and clean up json (#1)

### DIFF
--- a/org.fritzing.Fritzing.json
+++ b/org.fritzing.Fritzing.json
@@ -6,7 +6,8 @@
     "command": "Fritzing",
     "rename-icon": "fritzing",
     "finish-args": [
-        "--socket=fallback-x11", "--share=ipc",
+        "--socket=fallback-x11",
+        "--share=ipc",
         "--socket=wayland",
         "--device=dri",
         "--socket=pulseaudio",
@@ -33,13 +34,21 @@
                 {
                     "type": "archive",
                     "url": "https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz",
-                    "sha256": "205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6"
+                    "sha256": "205666dea9f6a7cfed87c7a6dfbeb52a2c1b9de55712c9c1a87735d7181452b6",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 6845,
+                        "stable-only": true,
+                        "url-template": "https://boostorg.jfrog.io/artifactory/main/release/$version/source/boost_${major}_${minor}_$patch.tar.bz2"
+                    }
                 }
             ]
         },
         {
             "name": "ngspice",
-            "build-options": {"strip": true},
+            "build-options": {
+                "strip": true
+            },
             "config-opts": [
                 "--enable-xspice",
                 "--enable-cider",
@@ -49,12 +58,16 @@
                 "--with-ngshared"
             ],
             "sources": [
-              {
-                "type": "git",
-                "url": "https://git.code.sf.net/p/ngspice/ngspice",
-                "tag": "ngspice-40",
-                "commit": "6eeb48bb5a1e0132ae7d58ac5cd05d9785c6b31c"
-              }
+                {
+                    "type": "git",
+                    "url": "https://git.code.sf.net/p/ngspice/ngspice",
+                    "tag": "ngspice-40",
+                    "commit": "6eeb48bb5a1e0132ae7d58ac5cd05d9785c6b31c",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^ngspice-([\\d]+)$"
+                    }
+                }
             ]
         },
         {
@@ -64,7 +77,13 @@
                 {
                     "type": "archive",
                     "url": "https://downloads.sourceforge.net/polyclipping/clipper_ver6.4.2.zip",
-                    "sha256": "a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627"
+                    "sha256": "a14320d82194807c4480ce59c98aa71cd4175a5156645c4e2b3edd330b930627",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 3683,
+                        "stable-only": true,
+                        "url-template": "https://downloads.sourceforge.net/polyclipping/clipper_ver${version}.zip"
+                    }
                 }
             ]
         },
@@ -73,9 +92,14 @@
             "buildsystem": "cmake-ninja",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/stachenov/quazip/archive/refs/tags/v1.4.tar.gz",
-                    "sha256": "79633fd3a18e2d11a7d5c40c4c79c1786ba0c74b59ad752e8429746fe1781dd6"
+                    "type": "git",
+                    "url": "https://github.com/stachenov/quazip",
+                    "tag": "v1.4",
+                    "commit": "566fa496649b8cb09018b497575bb3bf2977965f",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         },
@@ -90,7 +114,11 @@
                     "type": "git",
                     "url": "https://github.com/libgit2/libgit2",
                     "tag": "v1.7.2",
-                    "commit": "a418d9d4ab87bae16b87d8f37143a4687ae0e4b2"
+                    "commit": "a418d9d4ab87bae16b87d8f37143a4687ae0e4b2",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
             ]
         },
@@ -119,7 +147,11 @@
                     "url": "https://github.com/svgpp/svgpp.git",
                     "tag": "v1.3.1",
                     "commit": "fda1fd889548289178261d7aa02dd5d647247f94",
-                    "dest": "svgpp"
+                    "dest": "svgpp",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "patch",
@@ -135,8 +167,13 @@
                 {
                     "type": "git",
                     "url": "https://github.com/fritzing/fritzing-parts.git",
+                    "tag": "1.0.2",
                     "commit": "015626e6cafb1fc7831c2e536d97ca2275a83d32",
-                    "dest": "parts"
+                    "dest": "parts",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
* change the source type of quazip to git
* add x-data-checker for boost, ngspice, polyclipping, quazip, libgit2, svgpp, fritzing-parts
* clean up json formatting for x-data-checker